### PR TITLE
fix: 304 working

### DIFF
--- a/frontend/src/static/js/app.js
+++ b/frontend/src/static/js/app.js
@@ -1,4 +1,4 @@
-import { Router } from '/static/js/Router.js';
+import { Router, navigateTo } from '/static/js/Router.js';
 import { handleCallback } from './services/callbackHandler.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -11,5 +11,12 @@ document.addEventListener('DOMContentLoaded', () => {
             Router();
             window.addEventListener('popstate', Router);
         }
+    }
+});
+
+document.body.addEventListener('click', (e) => {
+    if (e.target.matches('[data-link]')) {
+        e.preventDefault();
+        navigateTo(e.target.href);
     }
 });


### PR DESCRIPTION
Avaliar a adoção do SPA, em teoria o que mudou foi o evento para impedir o reload forçando o uso do cache com essa função abaixo:

```
document.body.addEventListener('click', (e) => {
    if (e.target.matches('[data-link]')) {
        e.preventDefault();
        navigateTo(e.target.href);
    }
});
```

Eu testei as páginas e maioria teve o code 304 e a marcação de cache.

<img width="1351" alt="Screenshot 2024-07-06 at 14 19 38" src="https://github.com/tonnytg/42_transcendence/assets/1833882/ac2b3919-21b9-4460-a2e3-87a0a57d288d">

